### PR TITLE
Fix JSON injection via single-quote breakout in log fields

### DIFF
--- a/src/SeqProxy/Extensions.cs
+++ b/src/SeqProxy/Extensions.cs
@@ -3,16 +3,16 @@
 static class Extensions
 {
     public static string AsJson(this string value) =>
-        JavaScriptEncoder.UnsafeRelaxedJsonEscaping.Encode(value);
+        JavaScriptEncoder.Default.Encode(value);
 
     public static void WriteEscaped(this StringBuilder builder, string value)
     {
-        var encode = JsonEncodedText.Encode(value, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+        var encode = JsonEncodedText.Encode(value, JavaScriptEncoder.Default);
         builder.Append(encode);
     }
     public static void WriteEscaped(this StringBuilder builder, CharSpan value)
     {
-        var encode = JsonEncodedText.Encode(value, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+        var encode = JsonEncodedText.Encode(value, JavaScriptEncoder.Default);
         builder.Append(encode);
     }
 

--- a/src/Tests/InjectionTests.cs
+++ b/src/Tests/InjectionTests.cs
@@ -1,0 +1,82 @@
+using System.Security.Claims;
+using Argon;
+
+// Regression tests for the JSON/log-injection vulnerability (finding #1).
+// Attacker-controlled values (User-Agent / Referer headers and claim values) are
+// written into single-quoted JSON strings. They must be escaped so a value cannot
+// break out of its string and inject or override properties in the event sent to Seq.
+public class InjectionTests
+{
+    // If not escaped, the leading `'` closes the enclosing string and `,'Injected':'`
+    // injects a sibling property into the event.
+    const string Breakout = "evil','Injected':'pwned";
+
+    static async Task<JObject> Handle(MockRequest request, ClaimsPrincipal user)
+    {
+        var httpClient = new MockHttpClient();
+        var writer = new SeqWriter(
+            () => httpClient,
+            "http://theSeqUrl",
+            "theAppName",
+            new(1, 2),
+            "theApiKey",
+            _ => _,
+            "theServer",
+            "theUser");
+        await writer.Handle(user, request, new MockResponse());
+        // The body posted to Seq is exactly what the backend would parse.
+        return JObject.Parse(httpClient.Requests.Single().Body);
+    }
+
+    [Fact]
+    public async Task UserAgentHeaderCannotInjectProperties()
+    {
+        var request = new MockRequest("{'@mt':'Message'}");
+        request.Headers["User-Agent"] = Breakout;
+
+        var json = await Handle(request, new());
+
+        // The whole value stays inside UserAgent, and no breakout property is created.
+        Assert.Equal(Breakout, (string?)json["UserAgent"]);
+        Assert.Null(json["Injected"]);
+    }
+
+    [Fact]
+    public async Task RefererHeaderCannotInjectProperties()
+    {
+        var request = new MockRequest("{'@mt':'Message'}");
+        request.Headers["Referer"] = Breakout;
+
+        var json = await Handle(request, new());
+
+        Assert.Equal(Breakout, (string?)json["Referrer"]);
+        Assert.Null(json["Injected"]);
+    }
+
+    [Fact]
+    public async Task UserAgentHeaderCannotForgeTrustedField()
+    {
+        var request = new MockRequest("{'@mt':'Message'}");
+        request.Headers["User-Agent"] = "evil','Server':'spoofed";
+
+        var json = await Handle(request, new());
+
+        // The server-stamped `Server` value cannot be overridden via the header.
+        Assert.Equal("theServer", (string?)json["Server"]);
+    }
+
+    [Fact]
+    public async Task ClaimValueCannotInjectProperties()
+    {
+        // `'}` also tries to close the Claims object and inject a top-level property.
+        const string claimAttack = "evil'},'Injected':'pwned";
+        var identity = new ClaimsIdentity([new("name", claimAttack)], "scheme");
+        var request = new MockRequest("{'@mt':'Message'}");
+
+        var json = await Handle(request, new(identity));
+
+        Assert.Null(json["Injected"]);
+        var claims = (JObject)json["Claims"]!;
+        Assert.Equal(claimAttack, (string?)claims["name"]);
+    }
+}

--- a/src/Tests/SeqWriterTests.JsonEscapeClaim.verified.txt
+++ b/src/Tests/SeqWriterTests.JsonEscapeClaim.verified.txt
@@ -2,7 +2,7 @@
 'ApplicationVersion':'1.2',
 'Server':'theServer',
 'User':'theUser',
-'Claims':{'\"':'User@foo.bar',
-'\"':'theUserData'},
+'Claims':{'\u0022':'User@foo.bar',
+'\u0022':'theUserData'},
 '@t':'2019-05-28',
 '@mt':'Simple Message'}


### PR DESCRIPTION
Attacker-controlled values (User-Agent/Referer headers and claim values) are written into single-quoted JSON strings but were escaped with JavaScriptEncoder.UnsafeRelaxedJsonEscaping, which does not escape the single-quote delimiter. A header like  x','Server':'spoofed  could break out of its string to inject or forge properties (including the server-stamped Server/User/Claims) in the event sent to Seq.

Switch escaping to JavaScriptEncoder.Default, which escapes '. Output is unchanged for normal ASCII values and there is no perf impact.

Add InjectionTests covering the header and claim vectors.