### PR TITLE
Reject reserved proxy keys (SeqProxyId, Claims) in log events

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ var startOfYear = new DateTime(utcNow.Year, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 var ticks = utcNow.Ticks - startOfYear.Ticks;
 var id = ticks.ToString("x");
 ```
-<sup><a href='/src/SeqProxy/SeqWriter.cs#L94-L100' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildId' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/SeqProxy/SeqWriter.cs#L95-L101' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildId' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Which generates a string of the form `8e434f861302`. The current year is trimmed to shorten the id and under the assumption that retention policy is not longer than 12 months. There is a small chance of collisions, but given the use-case (error correlation), this should not impact the ability to find the correct error. This string can then be given to a user as a error correlation id.

--- a/src/SeqProxy/ReservedKeyValidator.cs
+++ b/src/SeqProxy/ReservedKeyValidator.cs
@@ -1,0 +1,22 @@
+static class ReservedKeyValidator
+{
+    // Properties that SeqProxy stamps itself and that a client must never supply in a log event,
+    // otherwise the client could forge them via the request body (which is appended after the
+    // server-stamped prefix). Limited to keys clients never legitimately use: generic names like
+    // Server/User/Application are intentionally NOT reserved, since clients send those as normal
+    // log properties (e.g. 'User':'John' to render "Hello, {User}").
+    public static void ThrowIfReservedKey(string line)
+    {
+        ThrowIfContainsKey(line, "SeqProxyId");
+        ThrowIfContainsKey(line, "Claims");
+    }
+
+    static void ThrowIfContainsKey(string line, string key)
+    {
+        if (line.Contains($"'{key}':") ||
+            line.Contains($"\"{key}\":"))
+        {
+            throw new($"'{key}' is reserved by SeqProxy and cannot be included in a log event.");
+        }
+    }
+}

--- a/src/SeqProxy/SeqWriter.cs
+++ b/src/SeqProxy/SeqWriter.cs
@@ -73,6 +73,7 @@ public class SeqWriter
             while (await reader.ReadLineAsync(cancel) is { } line)
             {
                 ValidateLine(line);
+                ReservedKeyValidator.ThrowIfReservedKey(line);
 
                 builder.Append(prefix);
                 if (!line.Contains("\"@t\"") &&

--- a/src/Tests/ReservedKeyValidatorTests.cs
+++ b/src/Tests/ReservedKeyValidatorTests.cs
@@ -1,0 +1,41 @@
+// Regression tests for finding #2: a client must not be able to forge the proxy-stamped
+// audit fields by supplying them in the request body. Only keys clients never legitimately
+// send are reserved (SeqProxyId, Claims); generic names like User/Server stay allowed.
+public class ReservedKeyValidatorTests
+{
+    [Theory]
+    [InlineData("{'@mt':'x','SeqProxyId':'forged'}")]
+    [InlineData("{'@mt':'x','Claims':{'role':'admin'}}")]
+    [InlineData("{\"@mt\":\"x\",\"SeqProxyId\":\"forged\"}")]
+    [InlineData("{\"@mt\":\"x\",\"Claims\":{}}")]
+    public void ReservedKeysAreRejected(string line) =>
+        Assert.Throws<Exception>(() => ReservedKeyValidator.ThrowIfReservedKey(line));
+
+    [Theory]
+    [InlineData("{'@mt':'Hello, {User}','User':'John'}")] // legitimate client property
+    [InlineData("{'@mt':'connected to {Server}','Server':'db01'}")] // legitimate client property
+    [InlineData("{'@mt':'x','Application':'ClientApp'}")]
+    [InlineData("{'@mt':'just a message'}")]
+    public void LegitimatePropertiesAreAllowed(string line) =>
+        ReservedKeyValidator.ThrowIfReservedKey(line);
+
+    [Fact]
+    public async Task ForgedEventIsNotForwardedToSeq()
+    {
+        var httpClient = new MockHttpClient();
+        var writer = new SeqWriter(
+            () => httpClient,
+            "http://theSeqUrl",
+            "theAppName",
+            new(1, 2),
+            "theApiKey",
+            _ => _,
+            "theServer",
+            "theUser");
+        var request = new MockRequest("{'@mt':'Message','SeqProxyId':'forged'}");
+
+        await Assert.ThrowsAsync<Exception>(() => writer.Handle(new(), request, new MockResponse()));
+        // Fail closed: nothing is forwarded to Seq.
+        Assert.Empty(httpClient.Requests);
+    }
+}


### PR DESCRIPTION
The request body is appended after the server-stamped prefix, so a client could forge the proxy-owned audit fields by supplying duplicate keys. Reject any event that contains SeqProxyId or Claims, failing closed before anything is sent to Seq.

Limited to keys clients never legitimately send: generic names like Server/User/Application stay allowed, since clients use those as normal log properties (e.g. 'User':'John' to render "Hello, {User}").

Add ReservedKeyValidatorTests covering rejection, the allowed generic names, and end-to-end fail-closed behaviour.