### PR TITLE
Send Seq api key as X-Seq-ApiKey header instead of URL query

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ var startOfYear = new DateTime(utcNow.Year, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 var ticks = utcNow.Ticks - startOfYear.Ticks;
 var id = ticks.ToString("x");
 ```
-<sup><a href='/src/SeqProxy/SeqWriter.cs#L81-L87' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildId' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/SeqProxy/SeqWriter.cs#L70-L76' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildId' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Which generates a string of the form `8e434f861302`. The current year is trimmed to shorten the id and under the assumption that retention policy is not longer than 12 months. There is a small chance of collisions, but given the use-case (error correlation), this should not impact the ability to find the correct error. This string can then be given to a user as a error correlation id.

--- a/src/SeqProxy/SeqWriter.cs
+++ b/src/SeqProxy/SeqWriter.cs
@@ -9,6 +9,7 @@ public class SeqWriter
 {
     Func<HttpClient> httpClientFunc;
     Uri url;
+    string? apiKey;
     PrefixBuilder prefixBuilder;
     static MediaTypeHeaderValue contentType = new("application/vnd.serilog.clef", Encoding.UTF8.WebName);
     static UTF8Encoding utf8NoBom = new(false);
@@ -20,7 +21,7 @@ public class SeqWriter
     /// <param name="seqUrl">The Seq api url.</param>
     /// <param name="application">The application name.</param>
     /// <param name="version">The application version.</param>
-    /// <param name="apiKey">The Seq api key to use. Will be appended to <paramref name="seqUrl"/> when writing log entries.</param>
+    /// <param name="apiKey">The Seq api key to use. Sent as an `X-Seq-ApiKey` header when writing log entries.</param>
     /// <param name="scrubClaimType">Scrubber for claim types. If null then <see cref="DefaultClaimTypeScrubber.Scrub"/> will be used.</param>
     /// <param name="server">The value to use for the Seq `Server` property.</param>
     /// <param name="user">The value to use for the Seq `User` property</param>
@@ -38,25 +39,13 @@ public class SeqWriter
         Ensure.NotNullOrEmpty(application);
         Ensure.NotNullOrEmpty(seqUrl);
         this.httpClientFunc = httpClientFunc;
-        url = GetSeqUrl(seqUrl, apiKey);
+        this.apiKey = apiKey;
+        url = GetSeqUrl(seqUrl);
         prefixBuilder = new(application, version, scrubClaimType, server, user);
     }
 
-    static Uri GetSeqUrl(string seqUrl, string? apiKey)
-    {
-        var baseUri = new Uri(seqUrl);
-        string uri;
-        if (apiKey is null)
-        {
-            uri = "api/events/raw";
-        }
-        else
-        {
-            uri = $"api/events/raw?apiKey={apiKey}";
-        }
-
-        return new(baseUri, uri);
-    }
+    static Uri GetSeqUrl(string seqUrl) =>
+        new(new Uri(seqUrl), "api/events/raw");
 
     /// <summary>
     /// Reads a log message from <paramref name="request"/> and forwards it to Seq.
@@ -94,7 +83,18 @@ public class SeqWriter
         var httpClient = httpClientFunc();
         try
         {
-            using var seqResponse = await httpClient.PostAsync(url, content, cancel);
+            // Send the Seq api key as a header rather than in the URL query string, so it is not
+            // exposed in request logs and does not need URL-encoding.
+            using var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = content
+            };
+            if (apiKey is not null)
+            {
+                request.Headers.Add("X-Seq-ApiKey", apiKey);
+            }
+
+            using var seqResponse = await httpClient.SendAsync(request, cancel);
             response.StatusCode = (int)seqResponse.StatusCode;
             response.Headers["SeqProxyId"] = id;
 

--- a/src/SeqProxy/SeqWriterConfig.cs
+++ b/src/SeqProxy/SeqWriterConfig.cs
@@ -26,7 +26,7 @@ public static class SeqWriterConfig
     /// <param name="seqUrl">The Seq api url.</param>
     /// <param name="application">The application name. If null then the name of <see cref="Assembly.GetCallingAssembly"/> will be used.</param>
     /// <param name="appVersion">The application version. If null then the version of <see cref="Assembly.GetCallingAssembly"/> will be used.</param>
-    /// <param name="apiKey">The Seq api key to use. Will be appended to <paramref name="seqUrl"/> when writing log entries.</param>
+    /// <param name="apiKey">The Seq api key to use. Sent as an `X-Seq-ApiKey` header when writing log entries.</param>
     /// <param name="server">The value to use for the Seq `Server` property. Defaults to <see cref="Environment.MachineName"/>.</param>
     /// <param name="user">The value to use for the Seq `User` property. Defaults to <see cref="Environment.UserName"/>.</param>
     /// <param name="scrubClaimType">Scrubber for claim types. If null then <see cref="DefaultClaimTypeScrubber.Scrub"/> will be used.</param>

--- a/src/Tests/ApiKeyTests.cs
+++ b/src/Tests/ApiKeyTests.cs
@@ -1,0 +1,38 @@
+// Regression tests for finding #4: the Seq api key must be sent as an X-Seq-ApiKey header,
+// not in the URL query string (where it leaks into request logs and needs URL-encoding).
+public class ApiKeyTests
+{
+    static async Task<LoggedRequest> Handle(string? apiKey)
+    {
+        var httpClient = new MockHttpClient();
+        var writer = new SeqWriter(
+            () => httpClient,
+            "http://theSeqUrl",
+            "theAppName",
+            new(1, 2),
+            apiKey,
+            _ => _,
+            "theServer",
+            "theUser");
+        await writer.Handle(new(), new MockRequest("{'@mt':'Message'}"), new MockResponse());
+        return httpClient.Requests.Single();
+    }
+
+    [Fact]
+    public async Task ApiKeyIsSentAsHeaderNotUrl()
+    {
+        var logged = await Handle("TheApiKey");
+
+        Assert.Equal("TheApiKey", logged.ApiKey);
+        Assert.Empty(logged.Uri!.Query);
+    }
+
+    [Fact]
+    public async Task NoApiKeyHeaderWhenNotConfigured()
+    {
+        var logged = await Handle(null);
+
+        Assert.Null(logged.ApiKey);
+        Assert.Empty(logged.Uri!.Query);
+    }
+}

--- a/src/Tests/Mocks/LoggedRequest.cs
+++ b/src/Tests/Mocks/LoggedRequest.cs
@@ -5,4 +5,6 @@
 
     public readonly string Body;
     public long? ContentLength;
+    public Uri? Uri;
+    public string? ApiKey;
 }

--- a/src/Tests/Mocks/MockHttpClient.cs
+++ b/src/Tests/Mocks/MockHttpClient.cs
@@ -6,8 +6,15 @@
     {
         // Captured before reading: a streamed (chunked) content has no precomputed length.
         var contentLength = request.Content!.Headers.ContentLength;
+        request.Headers.TryGetValues("X-Seq-ApiKey", out var apiKey);
         var content = await request.Content!.ReadAsStringAsync(cancel);
-        Requests.Add(new(content) { ContentLength = contentLength });
+        Requests.Add(
+            new(content)
+            {
+                ContentLength = contentLength,
+                Uri = request.RequestUri,
+                ApiKey = apiKey?.FirstOrDefault()
+            });
         return new(HttpStatusCode.OK)
         {
             Content = new StringContent("{\"MinimumLevelAccepted\":\"Information\"}")


### PR DESCRIPTION
The api key was appended unencoded to the Seq URL as ?apiKey=..., so it could leak into request/access logs of Seq or any intermediary, and a key with URL-significant characters would break or be truncated.

Send it as the X-Seq-ApiKey header instead (which Seq supports natively). Headers.Add also validates the value, rejecting a key with CRLF/control characters rather than mangling the URL.

Not a public API change (SeqWriter/AddSeqWriter signatures are unchanged) and behaviour-equivalent against a standard Seq server. The only observable difference is for an intermediary in front of Seq that keyed on the apiKey query parameter.

Add ApiKeyTests asserting the key is sent as a header and the URL query is empty.