### PR TITLE
Don't relay Seq error responses to the client

### DIFF
--- a/src/SeqProxy/SeqWriter.cs
+++ b/src/SeqProxy/SeqWriter.cs
@@ -95,10 +95,20 @@ public class SeqWriter
             }
 
             using var seqResponse = await httpClient.SendAsync(request, cancel);
-            response.StatusCode = (int)seqResponse.StatusCode;
             response.Headers["SeqProxyId"] = id;
 
-            await seqResponse.Content.CopyToAsync(response.Body, cancel);
+            if (seqResponse.IsSuccessStatusCode)
+            {
+                response.StatusCode = (int)seqResponse.StatusCode;
+                // Forward Seq's success body (e.g. MinimumLevelAccepted, used by clients for level control).
+                await seqResponse.Content.CopyToAsync(response.Body, cancel);
+            }
+            else
+            {
+                // Don't relay Seq's error status or body to the (possibly anonymous) client; that
+                // would disclose internal Seq details (version, config, ingestion errors).
+                response.StatusCode = StatusCodes.Status502BadGateway;
+            }
         }
         catch (TaskCanceledException)
         {

--- a/src/Tests/Mocks/MockHttpClient.cs
+++ b/src/Tests/Mocks/MockHttpClient.cs
@@ -1,6 +1,8 @@
 ﻿public class MockHttpClient : HttpClient
 {
     public List<LoggedRequest> Requests = [];
+    public HttpStatusCode ResponseStatus = HttpStatusCode.OK;
+    public string ResponseBody = "{\"MinimumLevelAccepted\":\"Information\"}";
 
     public override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, Cancel cancel)
     {
@@ -15,9 +17,9 @@
                 Uri = request.RequestUri,
                 ApiKey = apiKey?.FirstOrDefault()
             });
-        return new(HttpStatusCode.OK)
+        return new(ResponseStatus)
         {
-            Content = new StringContent("{\"MinimumLevelAccepted\":\"Information\"}")
+            Content = new StringContent(ResponseBody)
         };
     }
 }

--- a/src/Tests/UpstreamResponseTests.cs
+++ b/src/Tests/UpstreamResponseTests.cs
@@ -1,0 +1,56 @@
+// Regression tests for finding #5: the proxy must not relay Seq's raw error status/body to the
+// (possibly anonymous) client, since that discloses internal Seq details. Successful responses
+// (e.g. MinimumLevelAccepted, used for client-side level control) are still forwarded.
+public class UpstreamResponseTests
+{
+    static async Task<MockResponse> Handle(MockHttpClient httpClient)
+    {
+        var writer = new SeqWriter(
+            () => httpClient,
+            "http://theSeqUrl",
+            "theAppName",
+            new(1, 2),
+            "theApiKey",
+            _ => _,
+            "theServer",
+            "theUser");
+        var response = new MockResponse();
+        await writer.Handle(new(), new MockRequest("{'@mt':'Message'}"), response);
+        return response;
+    }
+
+    static string ReadBody(MockResponse response)
+    {
+        response.Body.Position = 0;
+        using var reader = new StreamReader(response.Body);
+        return reader.ReadToEnd();
+    }
+
+    [Fact]
+    public async Task SuccessResponseIsForwarded()
+    {
+        var response = await Handle(new());
+
+        Assert.Equal(200, response.StatusCode);
+        // Seq's success body is preserved so client-side level control keeps working.
+        Assert.Contains("MinimumLevelAccepted", ReadBody(response));
+    }
+
+    [Fact]
+    public async Task SeqErrorIsNotLeakedToClient()
+    {
+        var httpClient = new MockHttpClient
+        {
+            ResponseStatus = HttpStatusCode.Unauthorized,
+            ResponseBody = "Seq error: invalid API key for instance v2024.1"
+        };
+
+        var response = await Handle(httpClient);
+
+        // Generic gateway error; Seq's status and body are not disclosed.
+        Assert.Equal(502, response.StatusCode);
+        Assert.Empty(ReadBody(response));
+        // The correlation id is still returned.
+        Assert.True(response.Headers.ContainsKey("SeqProxyId"));
+    }
+}


### PR DESCRIPTION
The proxy forwarded Seq's exact status code and response body straight to the (possibly anonymous) client, disclosing internal Seq details on error: ingestion error messages, config/auth state, and version.

On a non-success status from Seq, return a generic 502 with no body. Keep forwarding successful responses unchanged so the MinimumLevelAccepted body (used by client-side sinks for dynamic level control) still works. The SeqProxyId correlation header is still returned either way.

Add UpstreamResponseTests covering both paths; MockHttpClient gains a configurable response status/body.